### PR TITLE
Add option to omit space between number and units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.bak
 *.bmarks
 *.layout
+.*.swp
 
 # Compiled Object files
 *.slo

--- a/examples/demo_eng_format.cpp
+++ b/examples/demo_eng_format.cpp
@@ -49,6 +49,9 @@ int main()
        "to_engineering_string( 1234, 3, eng_prefixed, \"Pa\" ): '" <<
         to_engineering_string( 1234, 3, eng_prefixed,  "Pa"  ) << "'\n" <<
 
+       "to_engineering_string( 1234, 3, eng_prefixed, \"Pa\", false ): '" <<
+        to_engineering_string( 1234, 3, eng_prefixed,  "Pa",  false ) << "'\n" <<
+
        "step_engineering_string(\"1.00 k\", 3, eng_prefixed, eng_increment ): '" <<
         step_engineering_string( "1.00 k" , 3, eng_prefixed, eng_increment ) << "'\n" << std::endl;
 

--- a/src/eng_format.cpp
+++ b/src/eng_format.cpp
@@ -128,9 +128,9 @@ int precision( double const scaled, int const digits )
     return is_zero( scaled ) ? digits - 1 : digits - log10( fabs( scaled ) ) - 2 * DBL_EPSILON;
 }
 
-std::string prefix_or_exponent( bool const exponential, int const degree )
+std::string prefix_or_exponent( bool const exponential, int const degree, bool const include_space )
 {
-    return std::string( exponential || 0 == degree ? "" : " " ) + prefixes[ exponential ][ sign(degree) > 0 ][ abs( degree ) ];
+    return std::string( !include_space || exponential || 0 == degree ? "" : " " ) + prefixes[ exponential ][ sign(degree) > 0 ][ abs( degree ) ];
 }
 
 std::string exponent( int const degree )
@@ -151,7 +151,7 @@ std::string engineering_to_exponent( std::string text );
  * convert real number to prefixed or exponential notation, optionally followed by a unit.
  */
 std::string
-to_engineering_string( double const value, int const digits, bool exponential, std::string const unit /*= ""*/ )
+to_engineering_string( double const value, int const digits, bool exponential, std::string const unit /*= ""*/, bool include_space /*= true*/ )
 {
     if      ( is_nan( value ) ) return "NaN";
     else if ( is_inf( value ) ) return "INFINITE";
@@ -162,7 +162,7 @@ to_engineering_string( double const value, int const digits, bool exponential, s
 
     if ( abs( degree ) < prefix_count )
     {
-        factor = prefix_or_exponent( exponential, degree );
+        factor = prefix_or_exponent( exponential, degree, include_space );
     }
     else
     {
@@ -174,7 +174,7 @@ to_engineering_string( double const value, int const digits, bool exponential, s
 
     const double scaled = value * pow( 1000.0, -degree );
 
-    const std::string space = ( 0 == degree || exponential ) && unit.length() ? " ":"";
+    const std::string space = include_space && ( 0 == degree || exponential ) && unit.length() ? " ":"";
 
     os << std::fixed << std::setprecision( precision( scaled, digits ) ) << scaled << factor << space << unit;
 

--- a/src/eng_format.hpp
+++ b/src/eng_format.hpp
@@ -30,7 +30,7 @@
  * exponential notation, optionally followed by a unit.
  */
 std::string
-to_engineering_string( double value, int digits, bool exponential, std::string unit = "" );
+to_engineering_string( double value, int digits, bool exponential, std::string unit = "", bool include_space = true );
 
 /**
  * convert the output of to_engineering_string() into a double.
@@ -79,9 +79,9 @@ const bool eng_decrement = false;
  * optionally followed by a unit.
  */
 inline std::string
-to_engineering_string( double value, int digits, eng_prefixed_t, std::string unit = "" )
+to_engineering_string( double value, int digits, eng_prefixed_t, std::string unit = "", bool include_space = true )
 {
-    return to_engineering_string( value, digits, false, unit );
+    return to_engineering_string( value, digits, false, unit, include_space );
 }
 
 /**

--- a/test/test_eng_format.cpp
+++ b/test/test_eng_format.cpp
@@ -100,6 +100,12 @@ const lest::test specification[] =
         ASSERT2( "123e0", to_engineering_string( 123, 3, eng_exponential ) );
     },
 
+    "number converts well to string without spaces", []()
+    {
+        ASSERT2( "1.23k", to_engineering_string( 1230, 3, false, "", false ) );
+        ASSERT2( "1.23k", to_engineering_string( 1230, 3, eng_prefixed, "", false ) );
+    },
+
     "string using prefix converts well to number", []()
     {
         ASSERT1( approx( 98.76e-3, from_engineering_string( "98.76 m" ) ) );


### PR DESCRIPTION
This lets you create strings like "1.23k" instead of "1.23 k".
