### PR TITLE
from_engineering_string improvements.

### DIFF
--- a/test/test_eng_format.cpp
+++ b/test/test_eng_format.cpp
@@ -110,7 +110,7 @@ const lest::test specification[] =
         EXPECT( approx( 98.76e-3, from_engineering_string( "98.76 ml" ) ) );
     },
 
-    CASE( "string using prefix and empty separator converts well to number" "[not-implemented]" )
+    CASE( "string using prefix and empty separator converts well to number" )
     {
         EXPECT( lest::approx( 98.76e-3 ) == from_engineering_string( "98.76m" ) );
 


### PR DESCRIPTION
from_engineering_string now works with no separator as well as any amount
of whitespace.

Update from_engineering_string to work with variable-length SI prefixes.  This
lets it work with a UTF-8 encoded micro ("\xce\xbc").

I have not added a unit test for variable-length prefixes. I think it could be useful to make the micro glyph settable at runtime as a global variable (instead of only being settable at compile time), and that would easily permit a unit test; I can do this as well if you like.
